### PR TITLE
Fairy modal QoL

### DIFF
--- a/brainlets/girlsfrontline/static/girlsfrontline/js/sim.js
+++ b/brainlets/girlsfrontline/static/girlsfrontline/js/sim.js
@@ -205,10 +205,10 @@ $(function () {
 
 function initEchelon() {
   echelon = [createDummyDoll(12),
-    createDummyDoll(22),
-    createDummyDoll(32),
-    createDummyDoll(13),
-    createDummyDoll(23)];
+  createDummyDoll(22),
+  createDummyDoll(32),
+  createDummyDoll(13),
+  createDummyDoll(23)];
   fairy = createDummyFairy();
 }
 
@@ -1546,7 +1546,13 @@ function changeFairy(event) {
     $('.fairy-skill-toggle').prop('checked', false);
     $('.fairy-skill-toggle').prop('disabled', true);
     fairy.useSkill = false;
+  } else if (fairy.id == 11) {
+    // Parachute fairy, disable skill by default
+    $('.fairy-skill-toggle').prop('checked', false);
+    fairy.useSkill = false;
   } else {
+    $('.fairy-skill-toggle').prop('checked', true);
+    fairy.useSkill = true;
     $('.fairy-skill-level-select').prop('disabled', false);
     $('.fairy-skill-toggle').prop('disabled', false);
   }

--- a/brainlets/girlsfrontline/templates/girlsfrontline/sim.html
+++ b/brainlets/girlsfrontline/templates/girlsfrontline/sim.html
@@ -1909,8 +1909,9 @@
                   <a class="btn" data-toggle="collapse" data-target="#combatfairy-list">
                     <img src="{% static 'girlsfrontline/sim/combat.png' %}" class="img-fluid"></img>
                   </a>
+                  <span style="vertical-align:middle;font-size:36px;font-family: 'Oswald', sans-serif;">Combat Fairies</span>
                 </div>
-                <div id="combatfairy-list" class="collapse">
+                <div id="combatfairy-list" class="collapse show">
                   <div class="card-body">
                     <div class="flex-row mb-3 combat">
                     </div>
@@ -1922,8 +1923,9 @@
                   <a class="btn" data-toggle="collapse" data-target="#tacticalfairy-list">
                     <img src="{% static 'girlsfrontline/sim/tactical.png' %}" class="img-fluid"></img>
                   </a>
+                  <span style="vertical-align:middle;font-size:36px;font-family: 'Oswald', sans-serif;">Strategy Fairies</span>
                 </div>
-                <div id="tacticalfairy-list" class="collapse">
+                <div id="tacticalfairy-list" class="collapse show">
                   <div class="card-body">
                     <div class="flex-row mb-3 tactical">
                     </div>


### PR DESCRIPTION
* Uncollapse both sections by default and show text labels "Combat Fairy"/"Strategy Fairy". 
* Parachute fairy skill use defaults to `false` now 